### PR TITLE
README: Using kubectl-sudo with other CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,13 @@ Works on systems with `/bin/sh` and kubectl >= 1.12. `kubectl` must be inside `$
 ## Configuration
 This plugin can be configured using environment variables:
 - `KUBECTL_SUDO_PROMPT=true` whether or not the plugin prompts the user before executing the kubectl command. Default value is `false`.
+
+## kubectl sudo with other CLIs
+
+`kubectl sudo` is a `kubectl` plugin, so it only works with `kubectl`.
+One option to use the`impersonate` mechanism described above with other CLIs that rely on kubeconfig (such as helm, k9s, 
+fluxctl, istioctl, etc.) is a "sudo-context".
+It's a duplicate of your usual `context` in kubeconfig that uses the same `cluster` but a different `user`.
+This user sets `as` and `as-groups` just like `kubectl sudo` does.
+
+One option for creating a "sudo context" can be found in [cloudogu/sudo-kubeconfig](https://github.com/cloudogu/sudo-kubeconfig).

--- a/README.md
+++ b/README.md
@@ -110,12 +110,5 @@ Works on systems with `/bin/sh` and kubectl >= 1.12. `kubectl` must be inside `$
 This plugin can be configured using environment variables:
 - `KUBECTL_SUDO_PROMPT=true` whether or not the plugin prompts the user before executing the kubectl command. Default value is `false`.
 
-## kubectl sudo with other CLIs
-
-`kubectl sudo` is a `kubectl` plugin, so it only works with `kubectl`.
-One option to use the`impersonate` mechanism described above with other CLIs that rely on kubeconfig (such as helm, k9s, 
-fluxctl, istioctl, etc.) is a "sudo-context".
-It's a duplicate of your usual `context` in kubeconfig that uses the same `cluster` but a different `user`.
-This user sets `as` and `as-groups` just like `kubectl sudo` does.
-
-One option for creating a "sudo context" can be found in [cloudogu/sudo-kubeconfig](https://github.com/cloudogu/sudo-kubeconfig).
+## Similar projects
+* [cloudogu/sudo-kubeconfig](https://github.com/cloudogu/sudo-kubeconfig): Create a sudo kubeconfig for your current kubernetes context.


### PR DESCRIPTION
Idea: Use a "sudo context" to overcome limitations of kubectl-sudo for aliases, plugins and other CLIs.

Would you be interested in adding [`create-sudo-kubeconfig.sh`](https://gist.github.com/schnatterer/2b1f2ca2bd66bad2644e6958aae9af6e) script to this repo? If so, I gladly add it to this PR. 

Thanks for this plugin and the idea to use `impersonate` as a sudo mechanism. This reduces the risks of accidental deployments significantly.