### PR TITLE
README: Add link to helm-sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,5 @@ This plugin can be configured using environment variables:
 - `KUBECTL_SUDO_PROMPT=true` whether or not the plugin prompts the user before executing the kubectl command. Default value is `false`.
 
 ## Similar projects
+* [cloudogu/helm-sudo](https://github.com/cloudogu/helm-sudo): Same functionality as kubectl-sudo for [helm](https://helm.sh/)
 * [cloudogu/sudo-kubeconfig](https://github.com/cloudogu/sudo-kubeconfig): Create a sudo kubeconfig for your current kubernetes context.


### PR DESCRIPTION
Hello again,

we liked your idea of `kubectl-sudo` so much, we ported it to helm.
We'd greatly appreciate if `helm-sudo` could be added to the "similar projects" section of your README.

helm-sudo already links to kubect-sudo of course :wink: 