### PR TITLE
chore: added missing quotes

### DIFF
--- a/bash/kubectl-sudo
+++ b/bash/kubectl-sudo
@@ -15,7 +15,7 @@ COMMAND=""
 
 for arg in "$@"
 do
-    if [ ${arg} != "--"* ] && [ -z "${COMMAND}" ]; then
+    if [ "${arg}" != "--"* ] && [ -z "${COMMAND}" ]; then
         COMMAND=${arg}
     fi
     plugin_path=$(which "kubectl-${COMMAND}" 2>/dev/null)


### PR DESCRIPTION
fixes "/usr/bin/kubectl-sudo: line 18: [: too many arguments" with lots of arguments